### PR TITLE
Exf time management

### DIFF
--- a/BFMcoupler_exf_load.F
+++ b/BFMcoupler_exf_load.F
@@ -1,0 +1,649 @@
+# include "BFMcoupler_OPTIONS.h"
+
+C--  File BFMcoupler_exf_load.F: Routines to read BFM fields with EXF                      
+C--   Contents
+C--   o BFMcoupler_EXF_LOAD                      
+C--   o BFMcoupler_EXF_READ_XY
+      
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|                              
+
+CBOP
+C     !ROUTINE: BFMcoupler_EXF_LOAD                                
+C     !INTERFACE:       
+      SUBROUTINE BFMcoupler_EXF_LOAD (
+     I                           myTime, myIter, myThid )
+
+C     !DESCRIPTION:                   
+C     *==============================================================*                 
+C     | SUBROUTINE BFMcoupler_EXF_LOAD
+C     *==============================================================*    
+C     | read BFM forcings from file
+C     | N.B.: * uses exf and cal routines for file/record handling
+C     |       * uses ctrl routines for control variable handling
+C     *==============================================================*
+
+C     !USES:
+      IMPLICIT NONE
+C     == Global variables ==                        
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "BFMcoupler_VARS.h"
+#include "BFMcoupler_LOAD.h"
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS:  
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#if ( defined ALLOW_EXF ) && ( defined ALLOW_BFMCOUPLER )
+C     !LOCAL VARIABLES:             
+CEOP
+      
+      CALL BFMcouplerS_EXF_READ_XY (
+     I     'BFMcoupler Surf', useBFMcouplerYearlyFields,
+     I     BFMcouplerSstartTime, BFMcouplerSperiod, BFMcouplerSrepCycle,
+     U     AtmosP,    atmosp0,    atmosp1,   BFMcoupler_AtmosPFile,
+     U     AtmosPCO2, atmospco20, atmospco21,BFMcoupler_PCO2File,
+#ifdef READ_PAR
+     U     spar,      spar0,      spar1,     BFMcoupler_sparFile,
+#endif
+     U     N1p_surfF, N1p_surfF0, N1p_surfF1,BFMcoupler_N1pSurfForcFile,
+     U     N3n_surfF, N3n_surfF0, N3n_surfF1,BFMcoupler_N3nSurfForcFile,
+     U     N5s_surfF, N5s_surfF0, N5s_surfF1,BFMcoupler_N5sSurfForcFile,
+     U     O3c_surfF, O3c_surfF0, O3c_surfF1,BFMcoupler_O3cSurfForcFile,
+     U     O3h_surfF, O3h_surfF0, O3h_surfF1,BFMcoupler_O3hSurfForcFile,
+     I     myTime, myIter, myThid )
+
+      CALL BFMcouplerB_EXF_READ_XY (
+     I     'BFMcoupler Bot', useBFMcouplerYearlyFields,
+     I     BFMcouplerBstartTime, BFMcouplerBperiod, BFMcouplerBrepCycle,
+     U     N1p_botF,  N1p_botF0,  N1p_botF1,BFMcoupler_N1pBotForcFile,
+     U     N3n_botF,  N3n_botF0,  N3n_botF1,BFMcoupler_N3nBotForcFile,
+     U     N4n_botF,  N4n_botF0,  N4n_botF1,BFMcoupler_N4nBotForcFile,
+     U     O2o_botF,  O2o_botF0,  O2o_botF1,BFMcoupler_O2oBotForcFile,
+     U     O3c_botF,  O3c_botF0,  O3c_botF1,BFMcoupler_O3cBotForcFile,
+     U     O3h_botF,  O3h_botF0,  O3h_botF1,BFMcoupler_O3hBotForcFile,
+     U     CONC01_botF, CONC01_botF0, CONC01_botF1,
+     U     BFMcoupler_CONC01BotForcFile,
+     U     CONC02_botF, CONC02_botF0, CONC02_botF1,
+     U     BFMcoupler_CONC02BotForcFile,
+     I     myTime, myIter, myThid )
+
+      CALL BFMcouplerK_EXF_READ_XY (
+     I     'BFMcoupler Kext', useBFMcouplerYearlyFields,
+     I     BFMcouplerKstartTime, BFMcouplerKperiod, BFMcouplerKrepCycle,
+#ifdef READ_xESP
+     U     xESP,      xESP0,      xESP1,     BFMcoupler_xESPFile,
+#endif
+     I     myTime, myIter, myThid )
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|                                         
+
+CBOP                                                                             
+C     !ROUTINE: BFMcouplerS_EXF_READ_XY             
+C     !INTERFACE:                            
+      SUBROUTINE BFMcouplerS_EXF_READ_XY (
+     I     bfmName, useYearlyFields,
+     I     bfmStartTime, bfmPeriod, bfmRepeatCycle,
+     U     AtmosP,    atmosp0,    atmosp1,   BFMcoupler_AtmosPFile,
+     U     AtmosPCO2, atmospco20, atmospco21,BFMcoupler_PCO2File,
+#ifdef READ_PAR
+     U     spar,      spar0,      spar1,     BFMcoupler_sparFile,
+#endif
+     U     N1p_surfF, N1p_surfF0, N1p_surfF1,BFMcoupler_N1pSurfForcFile,
+     U     N3n_surfF, N3n_surfF0, N3n_surfF1,BFMcoupler_N3nSurfForcFile,
+     U     N5s_surfF, N5s_surfF0, N5s_surfF1,BFMcoupler_N5sSurfForcFile,
+     U     O3c_surfF, O3c_surfF0, O3c_surfF1,BFMcoupler_O3cSurfForcFile,
+     U     O3h_surfF, O3h_surfF0, O3h_surfF1,BFMcoupler_O3hSurfForcFile,
+     I     myTime, myIter, myThid )
+
+C     !DESCRIPTION:                          
+C     *==============================================================*
+C     | SUBROUTINE BFMcouplerS_EXF_READ_XY                                   
+C     *==============================================================*
+C     | read BFM surface forcing from file                       
+C     | N.B.: * uses exf and cal routines for file/record handling    
+C     |       * uses ctrl routines for control variable handling      
+C     *==============================================================*
+
+C     !USES:                                 
+      IMPLICIT NONE
+C     == Global variables ==                 
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS: 
+      CHARACTER*(*) bfmName
+      LOGICAL useYearlyFields
+      _RL bfmStartTime, bfmPeriod, bfmRepeatCycle
+      _RL  AtmosPCO2(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  AtmosP(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#ifdef READ_PAR
+      _RL  spar(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif
+      _RL  N1p_surfF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  N3n_surfF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  N5s_surfF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  O3c_surfF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  O3h_surfF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      _RS AtmosPCO20  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS AtmosPCO21  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS AtmosP0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS AtmosP1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N1p_surfF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N1p_surfF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N3n_surfF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N3n_surfF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N5s_surfF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N5s_surfF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O3c_surfF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O3c_surfF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O3h_surfF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O3h_surfF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#ifdef READ_PAR
+      _RS spar0 (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS spar1 (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif
+
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_atmospFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_PCO2File
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_sparFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N1pSurfForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N3nSurfForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N5sSurfForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O3cSurfForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O3hSurfForcFile
+
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#if defined ALLOW_EXF
+C     !LOCAL VARIABLES:                               
+C     msgBuf     :: Informational/error message buffer
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+c      CHARACTER*(6) fldName
+      LOGICAL first, changed
+      INTEGER count0, count1
+      INTEGER year0, year1
+      _RL     fac
+CEOP
+
+      IF ( useCAL .AND. bfmPeriod .EQ. -12. _d 0 ) THEN
+# ifdef ALLOW_CAL
+C-    BFMcouplerPeriod=-12 means input file contains 12 monthly means 
+C     records, corresponding to Jan. (rec=1) through Dec. (rec=12)
+        CALL cal_GetMonthsRec(
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+# endif /* ALLOW_CAL */
+      ELSEIF ( useCal .AND. bfmPeriod .EQ. -1. _d 0 ) THEN
+C-    BFMcouplerPeriod=-1 means fields are monthly means.
+C     With useYearlyFields=.TRUE., each yearly input file contains
+C     12 monthly mean records.  Otherwise, a single input file contains
+C     monthly mean records starting at the month BFMcouplerStartTime falls in.
+# ifdef ALLOW_CAL
+        CALL EXF_GetMonthsRec(
+     I              bfmStartTime, useYearlyFields,
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+# endif /* ALLOW_CAL */
+      ELSEIF ( bfmPeriod .LT. 0. _d 0 ) THEN
+        WRITE(msgBuf,'(A,1PE16.8,3A)')
+     &        'BFMcoupler_EXF_READ_XY: Invalid BFMcouplerPeriod=',
+     &        bfmPeriod,
+     &        ' for ', bfmName, ' BFMcoupler files'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        STOP 'ABNORMAL END: S/R BFMcoupler_EXF_READ_XY'
+      ELSE
+C-    get record numbers and interpolation factor             
+        CALL EXF_GetFFieldRec(
+     I              bfmStartTime, bfmPeriod,
+     I              bfmRepeatCycle,
+     I              bfmName, useYearlyFields,
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+      ENDIF
+      IF ( exf_debugLev.GE.debLevD ) THEN
+         _BEGIN_MASTER( myThid )
+         WRITE(msgBuf,'(4A)') ' BFMcoupler_EXF_READ_XY: ',
+     &     'processing ', bfmName, '- files'
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A,I10,2I7)') ' BFMcoupler_EXF_READ_XY: ',
+     &     ' myIter, count0, count1:', myIter, count0, count1
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A,2(L2,2X),E16.9)') 'BFMcoupler_EXF_READ_XY: ',
+     &     ' first, changed, fac:  ', first, changed, fac
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         _END_MASTER( myThid )
+      ENDIF
+
+      IF ( BFMcoupler_atmospFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( AtmosP, atmosp0, atmosp1,
+     I                   BFMcoupler_atmospFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_PCO2File .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( AtmosPCO2, AtmospCO20, AtmospCO21,
+     I                   BFMcoupler_PCO2File,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_N1pSurfForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( N1p_surfF, N1p_surfF0, N1p_surfF1,
+     I                   BFMcoupler_N1pSurfForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_N3nSurfForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( N3n_surfF, N3n_surfF0, N3n_surfF1,
+     I                   BFMcoupler_N3nSurfForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( exf_debugLev.GE.debLevD ) THEN
+         _BEGIN_MASTER( myThid )
+         WRITE(msgBuf,'(A,F13.11)') ' N3n_surfF: ',
+     &     N3n_surfF(2,2,1,1)
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         _END_MASTER( myThid )
+      ENDIF
+      IF ( BFMcoupler_N5sSurfForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( N5s_surfF, N5s_surfF0, N5s_surfF1,
+     I                   BFMcoupler_N5sSurfForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_O3cSurfForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( O3c_surfF, O3c_surfF0, O3c_surfF1,
+     I                   BFMcoupler_O3cSurfForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_O3hSurfForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( O3h_surfF, O3h_surfF0, O3h_surfF1,
+     I                   BFMcoupler_O3hSurfForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+#ifdef READ_PAR
+      IF ( BFMcoupler_sparFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( spar, spar0, spar1,
+     I                   BFMcoupler_sparFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+       ENDIF
+#endif      
+
+#endif /* ALLOW_EXF */
+      RETURN
+      END
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|                                         
+
+CBOP                                                                             
+C     !ROUTINE: BFMcouplerB_EXF_READ_XY             
+C     !INTERFACE:                            
+      SUBROUTINE BFMcouplerB_EXF_READ_XY (
+     I     bfmName, useYearlyFields,
+     I     bfmStartTime, bfmPeriod, bfmRepeatCycle,
+     U     N1p_botF,  N1p_botF0,  N1p_botF1,BFMcoupler_N1pBotForcFile,
+     U     N3n_botF,  N3n_botF0,  N3n_botF1,BFMcoupler_N3nBotForcFile,
+     U     N4n_botF,  N4n_botF0,  N4n_botF1,BFMcoupler_N4nBotForcFile,
+     U     O2o_botF,  O2o_botF0,  O2o_botF1,BFMcoupler_O2oBotForcFile,
+     U     O3c_botF,  O3c_botF0,  O3c_botF1,BFMcoupler_O3cBotForcFile,
+     U     O3h_botF,  O3h_botF0,  O3h_botF1,BFMcoupler_O3hBotForcFile,
+     U     CONC01_botF, CONC01_botF0, CONC01_botF1,
+     U     BFMcoupler_CONC01BotForcFile,
+     U     CONC02_botF, CONC02_botF0, CONC02_botF1,
+     U     BFMcoupler_CONC02BotForcFile,
+     I     myTime, myIter, myThid )
+
+C     !DESCRIPTION:                          
+C     *==============================================================*
+C     | SUBROUTINE BFMcoupler_EXF_READ_XY                                   
+C     *==============================================================*
+C     | read BFM bottom forcing from file                       
+C     | N.B.: * uses exf and cal routines for file/record handling    
+C     |       * uses ctrl routines for control variable handling      
+C     *==============================================================*
+
+C     !USES:                                 
+      IMPLICIT NONE
+C     == Global variables ==                 
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS: 
+      CHARACTER*(*) bfmName
+      LOGICAL useYearlyFields
+      _RL  bfmStartTime, bfmPeriod, bfmRepeatCycle
+      _RL  N1p_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  N3n_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  N4n_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  O2o_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  O3c_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  O3h_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  CONC01_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  CONC02_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      _RS N1p_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N1p_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N3n_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N3n_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N4n_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS N4n_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O2o_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O2o_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O3c_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O3c_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O3h_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS O3h_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS CONC01_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS CONC01_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS CONC02_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS CONC02_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N1pBotForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N3nBotForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N4nBotForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O2oBotForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O3cBotForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O3hBotForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_CONC01BotForcFile
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_CONC02BotForcFile
+
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#if defined ALLOW_EXF
+C     !LOCAL VARIABLES:                               
+C     msgBuf     :: Informational/error message buffer
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+c      CHARACTER*(6) fldName
+      LOGICAL first, changed
+      INTEGER count0, count1
+      INTEGER year0, year1
+      _RL     fac
+CEOP
+
+      IF ( useCAL .AND. bfmPeriod .EQ. -12. _d 0 ) THEN
+# ifdef ALLOW_CAL
+C-    BFMcouplerPeriod=-12 means input file contains 12 monthly means 
+C     records, corresponding to Jan. (rec=1) through Dec. (rec=12)
+        CALL cal_GetMonthsRec(
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+# endif /* ALLOW_CAL */
+      ELSEIF ( useCal .AND. bfmPeriod .EQ. -1. _d 0 ) THEN
+C-    BFMcouplerPeriod=-1 means fields are monthly means.
+C     With useYearlyFields=.TRUE., each yearly input file contains
+C     12 monthly mean records.  Otherwise, a single input file contains
+C     monthly mean records starting at the month BFMcouplerStartTime falls in.
+# ifdef ALLOW_CAL
+        CALL EXF_GetMonthsRec(
+     I              bfmStartTime, useYearlyFields,
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+# endif /* ALLOW_CAL */
+      ELSEIF ( bfmPeriod .LT. 0. _d 0 ) THEN
+        WRITE(msgBuf,'(A,1PE16.8,3A)')
+     &        'BFMcoupler_EXF_READ_XY: Invalid BFMcouplerPeriod=',
+     &        bfmPeriod,
+     &        ' for ', bfmName, ' BFMcoupler files'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        STOP 'ABNORMAL END: S/R BFMcoupler_EXF_READ_XY'
+      ELSE
+C-    get record numbers and interpolation factor             
+        CALL EXF_GetFFieldRec(
+     I              bfmStartTime, bfmPeriod,
+     I              bfmRepeatCycle,
+     I              bfmName, useYearlyFields,
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+      ENDIF
+      IF ( exf_debugLev.GE.debLevD ) THEN
+         _BEGIN_MASTER( myThid )
+         WRITE(msgBuf,'(4A)') ' BFMcoupler_EXF_READ_XY: ',
+     &     'processing ', bfmName, '- files'
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A,I10,2I7)') ' BFMcoupler_EXF_READ_XY: ',
+     &     ' myIter, count0, count1:', myIter, count0, count1
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A,2(L2,2X),E16.9)') 'BFMcoupler_EXF_READ_XY: ',
+     &     ' first, changed, fac:  ', first, changed, fac
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         _END_MASTER( myThid )
+      ENDIF
+
+      IF ( BFMcoupler_N1pBotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( N1p_botF, N1p_botF0, N1p_botF1,
+     I                   BFMcoupler_N1pBotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_N3nBotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( N3n_botF, N3n_botF0, N3n_botF1,
+     I                   BFMcoupler_N3nBotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_N4nBotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( N4n_botF, N4n_botF0, N4n_botF1,
+     I                   BFMcoupler_N4nBotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_O2oBotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( O2o_botF, O2o_botF0, O2o_botF1,
+     I                   BFMcoupler_O2oBotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I        myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_O3cBotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( O3c_botF, O3c_botF0, O3c_botF1,
+     I                   BFMcoupler_O3cBotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_O3hBotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( O3h_botF, O3h_botF0, O3h_botF1,
+     I                   BFMcoupler_O3hBotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_CONC01BotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( CONC01_botF, CONC01_botF0, CONC01_botF1,
+     I                   BFMcoupler_CONC01BotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      IF ( BFMcoupler_CONC02BotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( CONC02_botF, CONC02_botF0, CONC02_botF1,
+     I                   BFMcoupler_CONC02BotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      
+#endif /* ALLOW_EXF */
+      RETURN
+      END
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|                                         
+
+CBOP                                                                             
+C     !ROUTINE: BFMcouplerK_EXF_READ_XY             
+C     !INTERFACE:                            
+      SUBROUTINE BFMcouplerK_EXF_READ_XY (
+     I     bfmName, useYearlyFields,
+     I     bfmStartTime, bfmPeriod, bfmRepeatCycle, 
+#ifdef READ_xESP
+     U     xESP,      xESP0,      xESP1,     BFMcoupler_xESPFile,
+#endif
+     I     myTime, myIter, myThid )
+
+C     !DESCRIPTION:                          
+C     *==============================================================*
+C     | SUBROUTINE BFMcouplerK_EXF_READ_XY                                   
+C     *==============================================================*
+C     | read BFM Kext forcing from file                       
+C     | N.B.: * uses exf and cal routines for file/record handling    
+C     |       * uses ctrl routines for control variable handling      
+C     *==============================================================*
+
+C     !USES:                                 
+      IMPLICIT NONE
+C     == Global variables ==                 
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS: 
+      CHARACTER*(*) bfmName
+      LOGICAL useYearlyFields
+      _RL  bfmStartTime, bfmPeriod, bfmRepeatCycle
+#ifdef READ_xESP      
+      _RL  xESP(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif
+#ifdef READ_xESP
+      _RS xESP0 (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS xESP1 (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif
+
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_xESPFile
+
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#if defined ALLOW_EXF
+C     !LOCAL VARIABLES:                               
+C     msgBuf     :: Informational/error message buffer
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+c      CHARACTER*(6) fldName
+      LOGICAL first, changed
+      INTEGER count0, count1
+      INTEGER year0, year1
+      _RL     fac
+CEOP
+
+      IF ( useCAL .AND. bfmPeriod .EQ. -12. _d 0 ) THEN
+# ifdef ALLOW_CAL
+C-    BFMcouplerPeriod=-12 means input file contains 12 monthly means 
+C     records, corresponding to Jan. (rec=1) through Dec. (rec=12)
+        CALL cal_GetMonthsRec(
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+# endif /* ALLOW_CAL */
+      ELSEIF ( useCal .AND. bfmPeriod .EQ. -1. _d 0 ) THEN
+C-    BFMcouplerPeriod=-1 means fields are monthly means.
+C     With useYearlyFields=.TRUE., each yearly input file contains
+C     12 monthly mean records.  Otherwise, a single input file contains
+C     monthly mean records starting at the month BFMcouplerStartTime falls in.
+# ifdef ALLOW_CAL
+        CALL EXF_GetMonthsRec(
+     I              bfmStartTime, useYearlyFields,
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+# endif /* ALLOW_CAL */
+      ELSEIF ( bfmPeriod .LT. 0. _d 0 ) THEN
+        WRITE(msgBuf,'(A,1PE16.8,3A)')
+     &        'BFMcoupler_EXF_READ_XY: Invalid BFMcouplerPeriod=',
+     &        bfmPeriod,
+     &        ' for ', bfmName, ' BFMcoupler files'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        STOP 'ABNORMAL END: S/R BFMcoupler_EXF_READ_XY'
+      ELSE
+C-    get record numbers and interpolation factor             
+        CALL EXF_GetFFieldRec(
+     I              bfmStartTime, bfmPeriod,
+     I              bfmRepeatCycle,
+     I              bfmName, useYearlyFields,
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+      ENDIF
+      IF ( exf_debugLev.GE.debLevD ) THEN
+         _BEGIN_MASTER( myThid )
+         WRITE(msgBuf,'(4A)') ' BFMcoupler_EXF_READ_XY: ',
+     &     'processing ', bfmName, '- files'
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A,I10,2I7)') ' BFMcoupler_EXF_READ_XY: ',
+     &     ' myIter, count0, count1:', myIter, count0, count1
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A,2(L2,2X),E16.9)') 'BFMcoupler_EXF_READ_XY: ',
+     &     ' first, changed, fac:  ', first, changed, fac
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         _END_MASTER( myThid )
+      ENDIF
+
+#ifdef READ_xESP
+      IF ( BFMcoupler_xESPFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( xESP, xESP0, xESP1,
+     I                   BFMcoupler_xESPFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+#endif
+      
+#endif /* ALLOW_EXF */
+      RETURN
+      END

--- a/add_tracers.py
+++ b/add_tracers.py
@@ -17,11 +17,13 @@ TARGET_TPL = [
     Path("BFMcoupler_ini_forcing.F.tpl"),
     Path("BFMcoupler_readparams.F.tpl"),
     Path("BFMcoupler_tr_register.F.tpl"),
+    Path("BFMcoupler_exf_load.F.tpl"),
 ]
 
 TARGET_STATIC = [
     Path("BFMcoupler_init_fixed.F"),
     Path("BFMcoupler_OPTIONS.h"),
+    Path("exf_set_BFMcoupler.F"),
 ]
 
 def copy_static(dest_dir: Path):

--- a/diff_apply.py
+++ b/diff_apply.py
@@ -612,7 +612,7 @@ NEW_LINES=[
 "     &    BFMcouplerBperiod,   BFMcouplerBrepCycle,",
 "     &    BFMcouplerKstartdate1,   BFMcouplerKstartdate2,",
 "     &    BFMcouplerKstartTime,",
-"     &    BFMcouplerKperiod,   BFMcouplerKrepCycle",
+"     &    BFMcouplerKperiod,   BFMcouplerKrepCycle,",
 "     &    BFMcouplerCstartdate1,   BFMcouplerCstartdate2,",
 "     &    BFMcouplerCstartTime,",
 "     &    BFMcouplerCperiod,   BFMcouplerCrepCycle",

--- a/diff_apply.py
+++ b/diff_apply.py
@@ -180,11 +180,34 @@ dumpfile(outfile, OUTLINES)
 filename="gchem_fields_load.F"
 infile=MITCODE + filename
 outfile=MYCODE + filename
+LINES, position_line = strings_and_position(infile, "#include \"GCHEM.h\"")
 LINES, position_line = strings_and_position(infile, "#endif /* ALLOW_GCHEM */")
+LINES, position_line = strings_and_position(infile, "      IMPLICIT NONE")
 
 NEW_LINES=[
+"#include \"SIZE.h\""]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+
+LINES=OUTLINES
+position_line = get_position_on_strings(LINES, "#include \"GCHEM.h\"")
+
+NEW_LINES=[
+"#include \"PARAMS.h\"",
+"#include \"EXF_PARAM.h\""]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+
+LINES=OUTLINES
+position_line = get_position_on_strings(LINES, "#endif /* ALLOW_GCHEM */")
+
+NEW_LINES=[
+"#if ( defined ALLOW_EXF ) && ( defined ALLOW_BFMCOUPLER )",
+"      IF ( useBFMexf .AND. useEXF .AND. useBFMcoupler ) THEN",
+"       CALL BFMcoupler_EXF_LOAD(myTime, myIter, myThid)",
+"      ENDIF",
+"#endif",
+"      ", 
 "#ifdef ALLOW_BFMCOUPLER",
-"      IF ( useBFMcoupler ) THEN",
+"      IF ( .NOT. (useBFMexf .AND. useEXF) .AND. useBFMcoupler ) THEN",
 "       CALl BFMcoupler_FIELDS_LOAD(myIter,myTime,myThid)",
 "      ENDIF",
 "#endif /* ALLOW_BFMCOUPLER */"]

--- a/diff_apply.py
+++ b/diff_apply.py
@@ -779,6 +779,86 @@ OUTLINES=insert_lines(LINES, NEW_LINES, position_line+8)
 LINES=OUTLINES
 dumpfile(outfile,LINES)
 
+MITCODE = INPUTDIR + "pkg/exf/"
+filename="EXF_PARAM.h"
+infile=MITCODE + filename
+outfile=MYCODE + filename
+LINES, position_line = strings_and_position(infile,"C                                  h/sflux, wspeed)")
+LINES, position_line = strings_and_position(infile,"      LOGICAL useOBCSYearlyFields")
+LINES, position_line = strings_and_position(infile, "      INTEGER exf_adjMonSelect")
+LINES, position_line = strings_and_position(infile, "      _RL     siobWrepCycle")
+LINES, position_line = strings_and_position(infile, "     &       useOBCSYearlyFields,")
+LINES, position_line = strings_and_position(infile, "     &       useStabilityFct_overIce, diags_opOceWeighted")
+LINES, position_line = strings_and_position(infile, "     &       siobWstartdate1,   siobWstartdate2")
+
+LINES, position_line = strings_and_position(infile,"C                                  h/sflux, wspeed)")
+NEW_LINES=[
+"C     useBFMexf          :: use BFMcoupler with EXF time management"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "      LOGICAL useOBCSYearlyFields")
+NEW_LINES=[
+"      LOGICAL useBFMcouplerYearlyFields"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "      INTEGER exf_adjMonSelect")
+NEW_LINES=[
+"",
+"      LOGICAL useBFMexf"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "      _RL     siobWrepCycle")
+NEW_LINES=[
+"",
+"      INTEGER BFMcouplerSstartdate1",
+"      INTEGER BFMcouplerSstartdate2",
+"      _RL     BFMcouplerSstartTime",
+"      _RL     BFMcouplerSperiod",
+"      _RL     BFMcouplerSrepCycle",
+"",
+"      INTEGER BFMcouplerBstartdate1",
+"      INTEGER BFMcouplerBstartdate2",
+"      _RL     BFMcouplerBstartTime",
+"      _RL     BFMcouplerBperiod",
+"      _RL     BFMcouplerBrepCycle",
+"",
+"      INTEGER BFMcouplerKstartdate1",
+"      INTEGER BFMcouplerKstartdate2",
+"      _RL     BFMcouplerKstartTime",
+"      _RL     BFMcouplerKperiod",
+"      _RL     BFMcouplerKrepCycle"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "     &       useOBCSYearlyFields,")
+NEW_LINES=[
+"     &       useBFMcouplerYearlyFields,"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+l0= "     &       useStabilityFct_overIce, diags_opOceWeighted"
+l1 = ["     &       useStabilityFct_overIce, diags_opOceWeighted,",
+"     &       useBFMexf"]
+LINES = replace_lines(LINES,l0, l1 )
+
+l0= "     &       siobWstartdate1,   siobWstartdate2"
+l1 = ["     &       siobWstartdate1,   siobWstartdate2,",
+"     &       BFMcouplerSstartdate1,   BFMcouplerSstartdate2,",
+"     &       BFMcouplerBstartdate1,   BFMcouplerBstartdate2,",
+"     &       BFMcouplerKstartdate1,   BFMcouplerKstartdate2"]
+LINES = replace_lines(LINES,l0, l1 )
+
+l0= "     &       siobWrepCycle,     siobWperiod,     siobWstartTime"
+l1 = ["     &       siobWrepCycle,     siobWperiod,     siobWstartTime,",
+"     &       BFMcouplerSrepCycle, BFMcouplerSperiod, BFMcouplerSstartTime,",
+"     &       BFMcouplerBrepCycle, BFMcouplerBperiod, BFMcouplerBstartTime,",
+"     &       BFMcouplerKrepCycle, BFMcouplerKperiod, BFMcouplerKstartTime"]
+LINES = replace_lines(LINES,l0, l1 )
+dumpfile(outfile,LINES)
+
 
 print("-------------------------------------------------")
 print("")

--- a/diff_apply.py
+++ b/diff_apply.py
@@ -870,7 +870,7 @@ l0= "     &       siobWstartdate1,   siobWstartdate2"
 l1 = ["     &       siobWstartdate1,   siobWstartdate2,",
 "     &       BFMcouplerSstartdate1,   BFMcouplerSstartdate2,",
 "     &       BFMcouplerBstartdate1,   BFMcouplerBstartdate2,",
-"     &       BFMcouplerKstartdate1,   BFMcouplerKstartdate2",
+"     &       BFMcouplerKstartdate1,   BFMcouplerKstartdate2,",
 "     &       BFMcouplerCstartdate1,   BFMcouplerCstartdate2"]
 LINES = replace_lines(LINES,l0, l1 )
 
@@ -878,7 +878,7 @@ l0= "     &       siobWrepCycle,     siobWperiod,     siobWstartTime"
 l1 = ["     &       siobWrepCycle,     siobWperiod,     siobWstartTime,",
 "     &       BFMcouplerSrepCycle, BFMcouplerSperiod, BFMcouplerSstartTime,",
 "     &       BFMcouplerBrepCycle, BFMcouplerBperiod, BFMcouplerBstartTime,",
-"     &       BFMcouplerKrepCycle, BFMcouplerKperiod, BFMcouplerKstartTime",
+"     &       BFMcouplerKrepCycle, BFMcouplerKperiod, BFMcouplerKstartTime,",
 "     &       BFMcouplerCrepCycle, BFMcouplerCperiod, BFMcouplerCstartTime"]
 LINES = replace_lines(LINES,l0, l1 )
 dumpfile(outfile,LINES)

--- a/diff_apply.py
+++ b/diff_apply.py
@@ -209,7 +209,7 @@ NEW_LINES=[
 "       CALL BFMcoupler_EXF_LOAD(myTime, myIter, myThid)",
 "      ENDIF",
 "#endif",
-"      ", 
+"", 
 "#ifdef ALLOW_BFMCOUPLER",
 "      IF ( .NOT. (useBFMexf .AND. useEXF) .AND. useBFMcoupler ) THEN",
 "       CALl BFMcoupler_FIELDS_LOAD(myIter,myTime,myThid)",
@@ -587,11 +587,11 @@ infile=MITCODE + filename
 outfile=MYCODE + filename
 LINES, position_line = strings_and_position(infile,"& humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac")
 LINES, position_line = strings_and_position(infile,"&        siobWperiod,   siobWrepCycle")
-LINES, position_line = strings_and_positions(infile, "      diags_opOceWeighted= .TRUE.")
-LINES, position_line = strings_and_positions(infile, "      siobWperiod        = UNSET_RL")
-LINES, position_line = strings_and_positions(infile, "      siobWstartTime     = UNSET_RL")
-LINES, position_line = strings_and_positions(infile, "      siobWrepCycle      = UNSET_RL")
-LINES, position_line = strings_and_positions(infile, "       IF(exf_iprec_obcs .EQ. UNSET_I) exf_iprec_obcs =exf_iprec")
+LINES, position_line = strings_and_position(infile, "      diags_opOceWeighted= .TRUE.")
+LINES, position_line = strings_and_position(infile, "      siobWperiod        = UNSET_RL")
+LINES, position_line = strings_and_position(infile, "      siobWstartTime     = UNSET_RL")
+LINES, position_line = strings_and_position(infile, "      siobWrepCycle      = UNSET_RL")
+LINES, position_line = strings_and_position(infile, "       IF(exf_iprec_obcs .EQ. UNSET_I) exf_iprec_obcs =exf_iprec")
 
 l0= "     & humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac"
 l1 = ["     & humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac,",
@@ -600,7 +600,7 @@ LINES = replace_lines(LINES,l0, l1 )
 
 position_line = get_position_on_strings(LINES, "     &        siobWperiod,   siobWrepCycle")
 NEW_LINES=[
-"       ",
+"",
 "#ifdef ALLOW_BFMCOUPLER",
 "      NAMELIST /EXF_NML_BFM/",
 "     &    useBFMcouplerYearlyFields,",
@@ -619,14 +619,14 @@ LINES=OUTLINES
 
 position_line = get_position_on_strings(LINES, "      diags_opOceWeighted= .TRUE.")
 NEW_LINES=[
-"       ",
+"",
 "      useBFMexf          = .FALSE."]
 OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
 LINES=OUTLINES
 
 position_line = get_position_on_strings(LINES, "      siobWperiod        = UNSET_RL")
 NEW_LINES=[
-"       ",
+"",
 "      useBFMcouplerYearlyFields = .FALSE.",
 "      BFMcouplerSstartdate1    = 0",
 "      BFMcouplerSstartdate2    = 0",
@@ -650,7 +650,7 @@ LINES=OUTLINES
 
 position_line = get_position_on_strings(LINES, "      siobWrepCycle      = UNSET_RL")
 NEW_LINES=[
-"       ",
+"",
 "      BFMcouplerSrepCycle = repeatPeriod",
 "      BFMcouplerBrepCycle = repeatPeriod",
 "      BFMcouplerKrepCycle = repeatPeriod"]
@@ -659,7 +659,7 @@ LINES=OUTLINES
 
 position_line = get_position_on_strings(LINES, "       IF(exf_iprec_obcs .EQ. UNSET_I) exf_iprec_obcs =exf_iprec")
 NEW_LINES=[
-"       ",
+"",
 "#ifdef ALLOW_BFMCOUPLER",
 "      IF ( useBFMexf ) THEN",
 "       WRITE(msgBuf,'(A)')",
@@ -670,6 +670,112 @@ NEW_LINES=[
 "      ENDIF",
 "#endif"]
 OUTLINES=insert_lines(LINES, NEW_LINES, position_line+2)
+LINES=OUTLINES
+dumpfile(outfile,LINES)
+
+MITCODE = INPUTDIR + "pkg/exf/"
+filename="exf_init_fixed.F"
+infile=MITCODE + filename
+outfile=MYCODE + filename
+LINES, position_line = strings_and_position(infile,"#include \"EXF_INTERP_PARAM.h\"")
+LINES, position_line = strings_and_position(infile, "#endif /* ALLOW_OBCS */")
+
+LINES, position_line = strings_and_position(infile,"#include \"EXF_INTERP_PARAM.h\"")
+NEW_LINES=[
+"#include \"GCHEM.h\""]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "#endif /* ALLOW_OBCS */")
+NEW_LINES=[
+"",
+"#ifdef ALLOW_BFMCOUPLER",
+"      IF ( useBFMcoupler .AND. useBFMexf ) THEN",
+"# ifdef ALLOW_DEBUG",
+"       IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START BFM Sur',myThid)",
+"# endif",
+"       CALL EXF_GETFFIELD_START( useBFMcouplerYearlyFields,",
+"     I                    'exf', 'BFM', BFMcouplerSperiod,",
+"     I                    BFMcouplerSstartdate1, BFMcouplerSstartdate2,",
+"     U                    BFMcouplerSstartTime, errCount,",
+"     I                    myThid )",
+"# ifdef ALLOW_DEBUG",
+"       IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START BFM Bot',myThid)",
+"# endif",
+"       CALL EXF_GETFFIELD_START( useBFMcouplerYearlyFields,",
+"     I                    'exf', 'BFM', BFMcouplerBperiod,",
+"     I                    BFMcouplerBstartdate1, BFMcouplerBstartdate2,",
+"     U                    BFMcouplerBstartTime, errCount,",
+"     I                    myThid )",
+"# ifdef ALLOW_DEBUG",
+"       IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START BFM Kex',myThid)",
+"# endif",
+"       CALL EXF_GETFFIELD_START( useBFMcouplerYearlyFields,",
+"     I                    'exf', 'BFM', BFMcouplerKperiod,",
+"     I                    BFMcouplerKstartdate1, BFMcouplerKstartdate2,",
+"     U                    BFMcouplerKstartTime, errCount,",
+"     I                    myThid )",
+"      ENDIF",
+"#endif /* ALLOW_BFMCOUPLER */"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+dumpfile(outfile,LINES)
+
+MITCODE = INPUTDIR + "pkg/exf/"
+filename="exf_swapffields.F"
+infile=MITCODE + filename
+outfile=MYCODE + filename
+LINES, position_line = strings_and_position(infile,"ffld1(j,k,bi,bj) = 0. _d 0")
+NEW_LINES=[
+"",
+"C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|",
+"",
+"      SUBROUTINE EXF_SWAPFFIELDS_XY(",
+"     O                            ffld0,",
+"     U                            ffld1,",
+"     I                            myThid )",
+"",
+"C     ==================================================================",
+"C     SUBROUTINE exf_swapffields_xy",
+"C     ==================================================================",
+"C",
+"C     o Copy a forcing field ffld1 to ffld0 and set ffld0 to zero.",
+"C",
+"C     ==================================================================",
+"C     SUBROUTINE exf_swapffields_xy",
+"C     ==================================================================",
+"",
+"      IMPLICIT NONE",
+"",
+"C     == global variables ==",
+"#include \"EEPARAMS.h\"",
+"#include \"SIZE.h\"",
+"",
+"C     == routine arguments ==",
+"      _RS ffld0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)",
+"      _RS ffld1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)",
+"      INTEGER myThid",
+"",
+"C     == local variables ==",
+"      INTEGER bi, bj",
+"      INTEGER i, j",
+"",
+"C     == end of interface ==",
+"",
+"      DO bj=myByLo(myThid),myByHi(myThid)",
+"        DO bi=myBxLo(myThid),myBxHi(myThid)",
+"          DO j = 1,sNy",
+"            DO i = 1,sNx",
+"              ffld0(i,j,bi,bj) = ffld1(i,j,bi,bj)",
+"              ffld1(i,j,bi,bj) = 0.",
+"            ENDDO",
+"          ENDDO",
+"        ENDDO",
+"      ENDDO",
+"",
+"      RETURN",
+"      END"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+8)
 LINES=OUTLINES
 dumpfile(outfile,LINES)
 

--- a/diff_apply.py
+++ b/diff_apply.py
@@ -587,6 +587,11 @@ infile=MITCODE + filename
 outfile=MYCODE + filename
 LINES, position_line = strings_and_position(infile,"& humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac")
 LINES, position_line = strings_and_position(infile,"&        siobWperiod,   siobWrepCycle")
+LINES, position_line = strings_and_positions(infile, "      diags_opOceWeighted= .TRUE.")
+LINES, position_line = strings_and_positions(infile, "      siobWperiod        = UNSET_RL")
+LINES, position_line = strings_and_positions(infile, "      siobWstartTime     = UNSET_RL")
+LINES, position_line = strings_and_positions(infile, "      siobWrepCycle      = UNSET_RL")
+LINES, position_line = strings_and_positions(infile, "       IF(exf_iprec_obcs .EQ. UNSET_I) exf_iprec_obcs =exf_iprec")
 
 l0= "     & humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac"
 l1 = ["     & humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac,",

--- a/diff_apply.py
+++ b/diff_apply.py
@@ -26,6 +26,10 @@ def argument():
    GAD_OPTIONS.h
    EXF_OPTIONS.h
    MNC_SIZE.h
+   exf_readparms.F
+   exf_init_fixed.F
+   exf_swapffields.F
+   EXF_PARAM.h
 
    by reading from MITgcm code
 '''
@@ -575,6 +579,93 @@ LINES = replace_lines(LINES,"parameter ( MNC_MAX_ID   =   3000 )",
                    ["      parameter ( MNC_MAX_ID   =   5000 )"])
 LINES = replace_lines(LINES,"parameter ( MNC_MAX_FID  =    200 )",
                    ["      parameter ( MNC_MAX_FID  =   5000 )"])
+dumpfile(outfile,LINES)
+
+MITCODE = INPUTDIR + "pkg/exf/"
+filename="exf_readparms.F"
+infile=MITCODE + filename
+outfile=MYCODE + filename
+LINES, position_line = strings_and_position(infile,"& humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac")
+LINES, position_line = strings_and_position(infile,"&        siobWperiod,   siobWrepCycle")
+
+l0= "     & humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac"
+l1 = ["     & humid_fac, gamma_blk, saltsat, sstExtrapol, psim_fac,",
+ "     & useBFMexf"]
+LINES = replace_lines(LINES,l0, l1 )
+
+position_line = get_position_on_strings(LINES, "     &        siobWperiod,   siobWrepCycle")
+NEW_LINES=[
+"       ",
+"#ifdef ALLOW_BFMCOUPLER",
+"      NAMELIST /EXF_NML_BFM/",
+"     &    useBFMcouplerYearlyFields,",
+"     &    BFMcouplerSstartdate1,   BFMcouplerSstartdate2,",
+"     &    BFMcouplerSstartTime,",
+"     &    BFMcouplerSperiod,   BFMcouplerSrepCycle,",
+"     &    BFMcouplerBstartdate1,   BFMcouplerBstartdate2,",
+"     &    BFMcouplerBstartTime,",
+"     &    BFMcouplerBperiod,   BFMcouplerBrepCycle,",
+"     &    BFMcouplerKstartdate1,   BFMcouplerKstartdate2,",
+"     &    BFMcouplerKstartTime,",
+"     &    BFMcouplerKperiod,   BFMcouplerKrepCycle",
+"#endif"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+2)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "      diags_opOceWeighted= .TRUE.")
+NEW_LINES=[
+"       ",
+"      useBFMexf          = .FALSE."]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "      siobWperiod        = UNSET_RL")
+NEW_LINES=[
+"       ",
+"      useBFMcouplerYearlyFields = .FALSE.",
+"      BFMcouplerSstartdate1    = 0",
+"      BFMcouplerSstartdate2    = 0",
+"      BFMcouplerSperiod        = 0.0 _d 0",
+"      BFMcouplerBstartdate1    = 0",
+"      BFMcouplerBstartdate2    = 0",
+"      BFMcouplerBperiod        = 0.0 _d 0",
+"      BFMcouplerKstartdate1    = 0",
+"      BFMcouplerKstartdate2    = 0",
+"      BFMcouplerKperiod        = 0.0 _d 0"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "      siobWstartTime     = UNSET_RL")
+NEW_LINES=[
+"      BFMcouplerSstartTime = UNSET_RL",
+"      BFMcouplerBstartTime = UNSET_RL",
+"      BFMcouplerKstartTime = UNSET_RL"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "      siobWrepCycle      = UNSET_RL")
+NEW_LINES=[
+"       ",
+"      BFMcouplerSrepCycle = repeatPeriod",
+"      BFMcouplerBrepCycle = repeatPeriod",
+"      BFMcouplerKrepCycle = repeatPeriod"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
+LINES=OUTLINES
+
+position_line = get_position_on_strings(LINES, "       IF(exf_iprec_obcs .EQ. UNSET_I) exf_iprec_obcs =exf_iprec")
+NEW_LINES=[
+"       ",
+"#ifdef ALLOW_BFMCOUPLER",
+"      IF ( useBFMexf ) THEN",
+"       WRITE(msgBuf,'(A)')",
+"     &      'EXF_READPARMS: reading EXF_NML_BFM'",
+"       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,",
+"     &                     SQUEEZE_RIGHT, myThid )",
+"       READ(  iUnit, nml = EXF_NML_BFM )",
+"      ENDIF",
+"#endif"]
+OUTLINES=insert_lines(LINES, NEW_LINES, position_line+2)
+LINES=OUTLINES
 dumpfile(outfile,LINES)
 
 

--- a/diff_apply.py
+++ b/diff_apply.py
@@ -613,6 +613,9 @@ NEW_LINES=[
 "     &    BFMcouplerKstartdate1,   BFMcouplerKstartdate2,",
 "     &    BFMcouplerKstartTime,",
 "     &    BFMcouplerKperiod,   BFMcouplerKrepCycle",
+"     &    BFMcouplerCstartdate1,   BFMcouplerCstartdate2,",
+"     &    BFMcouplerCstartTime,",
+"     &    BFMcouplerCperiod,   BFMcouplerCrepCycle",
 "#endif"]
 OUTLINES=insert_lines(LINES, NEW_LINES, position_line+2)
 LINES=OUTLINES
@@ -636,7 +639,10 @@ NEW_LINES=[
 "      BFMcouplerBperiod        = 0.0 _d 0",
 "      BFMcouplerKstartdate1    = 0",
 "      BFMcouplerKstartdate2    = 0",
-"      BFMcouplerKperiod        = 0.0 _d 0"]
+"      BFMcouplerKperiod        = 0.0 _d 0",
+"      BFMcouplerCstartdate1    = 0",
+"      BFMcouplerCstartdate2    = 0",
+"      BFMcouplerCperiod        = 0.0 _d 0"]
 OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
 LINES=OUTLINES
 
@@ -644,7 +650,8 @@ position_line = get_position_on_strings(LINES, "      siobWstartTime     = UNSET
 NEW_LINES=[
 "      BFMcouplerSstartTime = UNSET_RL",
 "      BFMcouplerBstartTime = UNSET_RL",
-"      BFMcouplerKstartTime = UNSET_RL"]
+"      BFMcouplerKstartTime = UNSET_RL",
+"      BFMcouplerCstartTime = UNSET_RL"]
 OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
 LINES=OUTLINES
 
@@ -653,7 +660,8 @@ NEW_LINES=[
 "",
 "      BFMcouplerSrepCycle = repeatPeriod",
 "      BFMcouplerBrepCycle = repeatPeriod",
-"      BFMcouplerKrepCycle = repeatPeriod"]
+"      BFMcouplerKrepCycle = repeatPeriod",
+"      BFMcouplerCrepCycle = repeatPeriod"]
 OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
 LINES=OUTLINES
 
@@ -714,6 +722,14 @@ NEW_LINES=[
 "     I                    'exf', 'BFM', BFMcouplerKperiod,",
 "     I                    BFMcouplerKstartdate1, BFMcouplerKstartdate2,",
 "     U                    BFMcouplerKstartTime, errCount,",
+"     I                    myThid )",
+"# ifdef ALLOW_DEBUG",
+"       IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START BFM Con',myThid)",
+"# endif",
+"       CALL EXF_GETFFIELD_START( useBFMcouplerYearlyFields,",
+"     I                    'exf', 'BFM', BFMcouplerCperiod,",
+"     I                    BFMcouplerCstartdate1, BFMcouplerCstartdate2,",
+"     U                    BFMcouplerCstartTime, errCount,",
 "     I                    myThid )",
 "      ENDIF",
 "#endif /* ALLOW_BFMCOUPLER */"]
@@ -829,7 +845,13 @@ NEW_LINES=[
 "      INTEGER BFMcouplerKstartdate2",
 "      _RL     BFMcouplerKstartTime",
 "      _RL     BFMcouplerKperiod",
-"      _RL     BFMcouplerKrepCycle"]
+"      _RL     BFMcouplerKrepCycle",
+"",
+"      INTEGER BFMcouplerCstartdate1",
+"      INTEGER BFMcouplerCstartdate2",
+"      _RL     BFMcouplerCstartTime",
+"      _RL     BFMcouplerCperiod",
+"      _RL     BFMcouplerCrepCycle"]
 OUTLINES=insert_lines(LINES, NEW_LINES, position_line+1)
 LINES=OUTLINES
 
@@ -848,14 +870,16 @@ l0= "     &       siobWstartdate1,   siobWstartdate2"
 l1 = ["     &       siobWstartdate1,   siobWstartdate2,",
 "     &       BFMcouplerSstartdate1,   BFMcouplerSstartdate2,",
 "     &       BFMcouplerBstartdate1,   BFMcouplerBstartdate2,",
-"     &       BFMcouplerKstartdate1,   BFMcouplerKstartdate2"]
+"     &       BFMcouplerKstartdate1,   BFMcouplerKstartdate2",
+"     &       BFMcouplerCstartdate1,   BFMcouplerCstartdate2"]
 LINES = replace_lines(LINES,l0, l1 )
 
 l0= "     &       siobWrepCycle,     siobWperiod,     siobWstartTime"
 l1 = ["     &       siobWrepCycle,     siobWperiod,     siobWstartTime,",
 "     &       BFMcouplerSrepCycle, BFMcouplerSperiod, BFMcouplerSstartTime,",
 "     &       BFMcouplerBrepCycle, BFMcouplerBperiod, BFMcouplerBstartTime,",
-"     &       BFMcouplerKrepCycle, BFMcouplerKperiod, BFMcouplerKstartTime"]
+"     &       BFMcouplerKrepCycle, BFMcouplerKperiod, BFMcouplerKstartTime",
+"     &       BFMcouplerCrepCycle, BFMcouplerCperiod, BFMcouplerCstartTime"]
 LINES = replace_lines(LINES,l0, l1 )
 dumpfile(outfile,LINES)
 

--- a/exf_set_BFMcoupler.F
+++ b/exf_set_BFMcoupler.F
@@ -1,0 +1,121 @@
+#include "EXF_OPTIONS.h"
+
+C--  File exf_set_BFMcoupler.F:
+C--   Contents
+C--   o EXF_SET_BFMcoupler
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+      SUBROUTINE EXF_SET_BFMcoupler (
+     U       BFMcoupler_fld_xy, BFMcoupler_fld0, BFMcoupler_fld1,
+     I       BFMcoupler_file, BFMcoupler_fldmask,
+     I       fac, first, changed, useYearlyFields, BFMcoupler_period,
+     I       count0, count1, year0, year1,
+     I       myTime, myIter, myThid )
+
+C     ==================================================================
+C     SUBROUTINE EXF_SET_BFMcoupler
+C     ==================================================================
+C
+C     o set BFMcoupler forcing
+C
+
+C     ==================================================================
+C     SUBROUTINE EXF_SET_BFMcoupler
+C     ==================================================================
+
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "GRID.h"
+#include "EXF_PARAM.h"
+#include "EXF_CONSTANTS.h"
+
+C     == routine arguments ==
+      _RL BFMcoupler_fld_xy(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS BFMcoupler_fld0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS BFMcoupler_fld1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      CHARACTER*(128) BFMcoupler_file
+      CHARACTER*1 BFMcoupler_fldmask
+      LOGICAL first, changed
+      LOGICAL useYearlyFields
+      _RL     BFMcoupler_period
+      INTEGER count0, count1, year0, year1
+      _RL     fac
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#ifdef ALLOW_BFMCOUPLER
+
+C     == local variables ==
+
+      CHARACTER*(128) BFMcoupler_file0, BFMcoupler_file1
+      INTEGER bi, bj
+      INTEGER i, j
+
+C     == end of interface ==
+
+      IF ( BFMcoupler_file .NE. ' ' ) THEN
+
+         IF ( first ) THEN
+
+            CALL exf_GetYearlyFieldName(
+     I         useYearlyFields, twoDigitYear, BFMcoupler_period, year0,
+     I         BFMcoupler_file,
+     O         BFMcoupler_file0,
+     I         myTime, myIter, myThid )
+
+            _BARRIER
+            CALL READ_REC_XY_RS( BFMcoupler_file0, BFMcoupler_fld1,
+     &                           count0, myIter, myThid)
+            _BARRIER
+C-     apply mask Eventually evaluate if necessary to apply the mask: 
+c                 in case it should be created a new file  exf_filter_rs.F
+
+c     CALL EXF_FILTER_RL( BFMcoupler_fld1, BFMcoupler_fldMask,
+c     &                          myThid )            
+         ENDIF
+
+         IF ( first .OR. changed ) THEN
+C-     In exf_swapffields.F I add a routine exf_swapffields_xy             
+c      identical to swapffields, but with fld0 and fld1 of type _RS
+            CALL exf_swapffields_xy( BFMcoupler_fld0, BFMcoupler_fld1,
+     &                                myThid )
+
+            CALL exf_GetYearlyFieldName(
+     I         useYearlyFields, twoDigitYear, BFMcoupler_period, year1,
+     I         BFMcoupler_file,
+     O         BFMcoupler_file1,
+     I         myTime, myIter, myThid )
+
+            _BARRIER
+            CALL READ_REC_XY_RS( BFMcoupler_file1, BFMcoupler_fld1,
+     &                           count1, myIter, myThid)
+            _BARRIER
+         ENDIF
+
+         _EXCH_XY_RS(BFMcoupler_fld0, myThid )
+         _EXCH_XY_RS(BFMcoupler_fld1, myThid )
+         
+         DO bj = myByLo(myThid),myByHi(myThid)
+            DO bi = myBxLo(myThid),myBxHi(myThid)
+               DO j = 1-OLy,sNy+OLy
+                  DO i = 1-OLx,sNx+OLx
+                     BFMcoupler_fld_xy(i,j,bi,bj) =
+     &                    fac * BFMcoupler_fld0(i,j,bi,bj) +
+     &                    (exf_one - fac) * BFMcoupler_fld1(i,j,bi,bj)
+                  ENDDO
+               ENDDO
+            ENDDO
+         ENDDO
+
+      ENDIF
+
+#endif /* ALLOW_BFMCOUPLER */
+
+      RETURN
+      END

--- a/tpl/BFMcoupler_exf_load.F.tpl
+++ b/tpl/BFMcoupler_exf_load.F.tpl
@@ -67,10 +67,6 @@ CEOP
      U     O2o_botF,  O2o_botF0,  O2o_botF1,BFMcoupler_O2oBotForcFile,
      U     O3c_botF,  O3c_botF0,  O3c_botF1,BFMcoupler_O3cBotForcFile,
      U     O3h_botF,  O3h_botF0,  O3h_botF1,BFMcoupler_O3hBotForcFile,
-     {%- for i in range(1, n_tracers + 1) %}
-     U     CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
-     U     BFMcoupler_CONC{{'%02d' % i}}BotForcFile,
-     {%- endfor %}
      I     myTime, myIter, myThid )
 
       CALL BFMcouplerK_EXF_READ_XY (
@@ -79,6 +75,15 @@ CEOP
 #ifdef READ_xESP
      U     xESP,      xESP0,      xESP1,     BFMcoupler_xESPFile,
 #endif
+     I     myTime, myIter, myThid )
+
+      CALL BFMcouplerC_EXF_READ_XY (
+     I     'BFMcoupler Con', useBFMcouplerYearlyFields,
+     I     BFMcouplerCstartTime, BFMcouplerCperiod, BFMcouplerCrepCycle,
+     {%- for i in range(1, n_tracers + 1) %}
+     U     CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
+     U     BFMcoupler_CONC{{'%02d' % i}}BotForcFile,
+     {%- endfor %}
      I     myTime, myIter, myThid )
 
       RETURN
@@ -322,10 +327,6 @@ C     !INTERFACE:
      U     O2o_botF,  O2o_botF0,  O2o_botF1,BFMcoupler_O2oBotForcFile,
      U     O3c_botF,  O3c_botF0,  O3c_botF1,BFMcoupler_O3cBotForcFile,
      U     O3h_botF,  O3h_botF0,  O3h_botF1,BFMcoupler_O3hBotForcFile,
-     {%- for i in range(1, n_tracers + 1) %}
-     U     CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
-     U     BFMcoupler_CONC{{'%02d' % i}}BotForcFile,
-     {%- endfor %}
      I     myTime, myIter, myThid )
 
 C     !DESCRIPTION:                          
@@ -357,9 +358,6 @@ C     !INPUT/OUTPUT PARAMETERS:
       _RL  O2o_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  O3c_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  O3h_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      {%- for i in range(1, n_tracers + 1) %}
-      _RL  CONC{{'%02d' % i}}_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      {%- endfor %}
 
       _RS N1p_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS N1p_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -373,10 +371,6 @@ C     !INPUT/OUTPUT PARAMETERS:
       _RS O3c_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS O3h_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS O3h_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      {%- for i in range(1, n_tracers + 1) %}
-      _RS CONC{{'%02d' % i}}_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RS CONC{{'%02d' % i}}_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      {%- endfor %}
 
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N1pBotForcFile
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N3nBotForcFile
@@ -384,9 +378,6 @@ C     !INPUT/OUTPUT PARAMETERS:
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O2oBotForcFile
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O3cBotForcFile
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O3hBotForcFile
-      {%- for i in range(1, n_tracers + 1) %}
-      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_CONC{{'%02d' % i}}BotForcFile
-      {%- endfor %}
 
       _RL     myTime
       INTEGER myIter
@@ -500,15 +491,6 @@ C-    get record numbers and interpolation factor
      I                   bfmPeriod, count0, count1, year0, year1,
      I                   myTime, myIter, myThid )
       ENDIF
-      {%- for i in range(1, n_tracers + 1) %}
-      IF ( BFMcoupler_CONC{{'%02d' % i}}BotForcFile .NE. ' ' ) THEN
-       CALL EXF_SET_BFMcoupler( CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
-     I                   BFMcoupler_CONC{{'%02d' % i}}BotForcFile,'c',
-     I                   fac, first, changed, useYearlyFields,
-     I                   bfmPeriod, count0, count1, year0, year1,
-     I                   myTime, myIter, myThid )
-      ENDIF
-      {%- endfor %}
       
 #endif /* ALLOW_EXF */
       RETURN
@@ -640,6 +622,141 @@ C-    get record numbers and interpolation factor
      I                   myTime, myIter, myThid )
       ENDIF
 #endif
+      
+#endif /* ALLOW_EXF */
+      RETURN
+      END
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|                                         
+
+CBOP                                                                             
+C     !ROUTINE: BFMcouplerC_EXF_READ_XY             
+C     !INTERFACE:                            
+      SUBROUTINE BFMcouplerC_EXF_READ_XY (
+     I     bfmName, useYearlyFields,
+     I     bfmStartTime, bfmPeriod, bfmRepeatCycle,
+     {%- for i in range(1, n_tracers + 1) %}
+     U     CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
+     U     BFMcoupler_CONC{{'%02d' % i}}BotForcFile,
+     {%- endfor %}
+     I     myTime, myIter, myThid )
+
+C     !DESCRIPTION:                          
+C     *==============================================================*
+C     | SUBROUTINE BFMcoupler_EXF_READ_XY                                   
+C     *==============================================================*
+C     | read BFM bottom forcing from file                       
+C     | N.B.: * uses exf and cal routines for file/record handling    
+C     |       * uses ctrl routines for control variable handling      
+C     *==============================================================*
+
+C     !USES:                                 
+      IMPLICIT NONE
+C     == Global variables ==                 
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS: 
+      CHARACTER*(*) bfmName
+      LOGICAL useYearlyFields
+      _RL  bfmStartTime, bfmPeriod, bfmRepeatCycle
+      {%- for i in range(1, n_tracers + 1) %}
+      _RL  CONC{{'%02d' % i}}_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      {%- endfor %}
+
+      {%- for i in range(1, n_tracers + 1) %}
+      _RS CONC{{'%02d' % i}}_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS CONC{{'%02d' % i}}_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      {%- endfor %}
+
+      {%- for i in range(1, n_tracers + 1) %}
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_CONC{{'%02d' % i}}BotForcFile
+      {%- endfor %}
+
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#if defined ALLOW_EXF
+C     !LOCAL VARIABLES:                               
+C     msgBuf     :: Informational/error message buffer
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+c      CHARACTER*(6) fldName
+      LOGICAL first, changed
+      INTEGER count0, count1
+      INTEGER year0, year1
+      _RL     fac
+CEOP
+
+      IF ( useCAL .AND. bfmPeriod .EQ. -12. _d 0 ) THEN
+# ifdef ALLOW_CAL
+C-    BFMcouplerPeriod=-12 means input file contains 12 monthly means 
+C     records, corresponding to Jan. (rec=1) through Dec. (rec=12)
+        CALL cal_GetMonthsRec(
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+# endif /* ALLOW_CAL */
+      ELSEIF ( useCal .AND. bfmPeriod .EQ. -1. _d 0 ) THEN
+C-    BFMcouplerPeriod=-1 means fields are monthly means.
+C     With useYearlyFields=.TRUE., each yearly input file contains
+C     12 monthly mean records.  Otherwise, a single input file contains
+C     monthly mean records starting at the month BFMcouplerStartTime falls in.
+# ifdef ALLOW_CAL
+        CALL EXF_GetMonthsRec(
+     I              bfmStartTime, useYearlyFields,
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+# endif /* ALLOW_CAL */
+      ELSEIF ( bfmPeriod .LT. 0. _d 0 ) THEN
+        WRITE(msgBuf,'(A,1PE16.8,3A)')
+     &        'BFMcoupler_EXF_READ_XY: Invalid BFMcouplerPeriod=',
+     &        bfmPeriod,
+     &        ' for ', bfmName, ' BFMcoupler files'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        STOP 'ABNORMAL END: S/R BFMcoupler_EXF_READ_XY'
+      ELSE
+C-    get record numbers and interpolation factor             
+        CALL EXF_GetFFieldRec(
+     I              bfmStartTime, bfmPeriod,
+     I              bfmRepeatCycle,
+     I              bfmName, useYearlyFields,
+     O              fac, first, changed,
+     O              count0, count1, year0, year1,
+     I              myTime, myIter, myThid )
+      ENDIF
+      IF ( exf_debugLev.GE.debLevD ) THEN
+         _BEGIN_MASTER( myThid )
+         WRITE(msgBuf,'(4A)') ' BFMcoupler_EXF_READ_XY: ',
+     &     'processing ', bfmName, '- files'
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A,I10,2I7)') ' BFMcoupler_EXF_READ_XY: ',
+     &     ' myIter, count0, count1:', myIter, count0, count1
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A,2(L2,2X),E16.9)') 'BFMcoupler_EXF_READ_XY: ',
+     &     ' first, changed, fac:  ', first, changed, fac
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         _END_MASTER( myThid )
+      ENDIF
+
+      {%- for i in range(1, n_tracers + 1) %}
+      IF ( BFMcoupler_CONC{{'%02d' % i}}BotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
+     I                   BFMcoupler_CONC{{'%02d' % i}}BotForcFile,'c',
+     I                   fac, first, changed, useYearlyFields,
+     I                   bfmPeriod, count0, count1, year0, year1,
+     I                   myTime, myIter, myThid )
+      ENDIF
+      {%- endfor %}
       
 #endif /* ALLOW_EXF */
       RETURN

--- a/tpl/BFMcoupler_exf_load.F.tpl
+++ b/tpl/BFMcoupler_exf_load.F.tpl
@@ -67,10 +67,10 @@ CEOP
      U     O2o_botF,  O2o_botF0,  O2o_botF1,BFMcoupler_O2oBotForcFile,
      U     O3c_botF,  O3c_botF0,  O3c_botF1,BFMcoupler_O3cBotForcFile,
      U     O3h_botF,  O3h_botF0,  O3h_botF1,BFMcoupler_O3hBotForcFile,
-     U     CONC01_botF, CONC01_botF0, CONC01_botF1,
-     U     BFMcoupler_CONC01BotForcFile,
-     U     CONC02_botF, CONC02_botF0, CONC02_botF1,
-     U     BFMcoupler_CONC02BotForcFile,
+     {%- for i in range(1, n_tracers + 1) %}
+     U     CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
+     U     BFMcoupler_CONC{{'%02d' % i}}BotForcFile,
+     {%- endfor %}
      I     myTime, myIter, myThid )
 
       CALL BFMcouplerK_EXF_READ_XY (
@@ -322,10 +322,10 @@ C     !INTERFACE:
      U     O2o_botF,  O2o_botF0,  O2o_botF1,BFMcoupler_O2oBotForcFile,
      U     O3c_botF,  O3c_botF0,  O3c_botF1,BFMcoupler_O3cBotForcFile,
      U     O3h_botF,  O3h_botF0,  O3h_botF1,BFMcoupler_O3hBotForcFile,
-     U     CONC01_botF, CONC01_botF0, CONC01_botF1,
-     U     BFMcoupler_CONC01BotForcFile,
-     U     CONC02_botF, CONC02_botF0, CONC02_botF1,
-     U     BFMcoupler_CONC02BotForcFile,
+     {%- for i in range(1, n_tracers + 1) %}
+     U     CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
+     U     BFMcoupler_CONC{{'%02d' % i}}BotForcFile,
+     {%- endfor %}
      I     myTime, myIter, myThid )
 
 C     !DESCRIPTION:                          
@@ -357,8 +357,9 @@ C     !INPUT/OUTPUT PARAMETERS:
       _RL  O2o_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  O3c_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  O3h_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL  CONC01_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL  CONC02_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      {%- for i in range(1, n_tracers + 1) %}
+      _RL  CONC{{'%02d' % i}}_botF(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      {%- endfor %}
 
       _RS N1p_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS N1p_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -372,10 +373,10 @@ C     !INPUT/OUTPUT PARAMETERS:
       _RS O3c_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS O3h_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS O3h_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RS CONC01_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RS CONC01_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RS CONC02_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RS CONC02_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      {%- for i in range(1, n_tracers + 1) %}
+      _RS CONC{{'%02d' % i}}_botF0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS CONC{{'%02d' % i}}_botF1  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      {%- endfor %}
 
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N1pBotForcFile
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_N3nBotForcFile
@@ -383,8 +384,9 @@ C     !INPUT/OUTPUT PARAMETERS:
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O2oBotForcFile
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O3cBotForcFile
       CHARACTER*(MAX_LEN_FNAM) BFMcoupler_O3hBotForcFile
-      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_CONC01BotForcFile
-      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_CONC02BotForcFile
+      {%- for i in range(1, n_tracers + 1) %}
+      CHARACTER*(MAX_LEN_FNAM) BFMcoupler_CONC{{'%02d' % i}}BotForcFile
+      {%- endfor %}
 
       _RL     myTime
       INTEGER myIter
@@ -498,20 +500,15 @@ C-    get record numbers and interpolation factor
      I                   bfmPeriod, count0, count1, year0, year1,
      I                   myTime, myIter, myThid )
       ENDIF
-      IF ( BFMcoupler_CONC01BotForcFile .NE. ' ' ) THEN
-       CALL EXF_SET_BFMcoupler( CONC01_botF, CONC01_botF0, CONC01_botF1,
-     I                   BFMcoupler_CONC01BotForcFile,'c',
+      {%- for i in range(1, n_tracers + 1) %}
+      IF ( BFMcoupler_CONC{{'%02d' % i}}BotForcFile .NE. ' ' ) THEN
+       CALL EXF_SET_BFMcoupler( CONC{{'%02d' % i}}_botF, CONC{{'%02d' % i}}_botF0, CONC{{'%02d' % i}}_botF1,
+     I                   BFMcoupler_CONC{{'%02d' % i}}BotForcFile,'c',
      I                   fac, first, changed, useYearlyFields,
      I                   bfmPeriod, count0, count1, year0, year1,
      I                   myTime, myIter, myThid )
       ENDIF
-      IF ( BFMcoupler_CONC02BotForcFile .NE. ' ' ) THEN
-       CALL EXF_SET_BFMcoupler( CONC02_botF, CONC02_botF0, CONC02_botF1,
-     I                   BFMcoupler_CONC02BotForcFile,'c',
-     I                   fac, first, changed, useYearlyFields,
-     I                   bfmPeriod, count0, count1, year0, year1,
-     I                   myTime, myIter, myThid )
-      ENDIF
+      {%- endfor %}
       
 #endif /* ALLOW_EXF */
       RETURN


### PR DESCRIPTION
close inogs/mer#1088

This PR proposes a series of modifications to the source files of the MITgcm via the BFMcoupler to introduce a time management of the BFM external forcing files through the EXF package of the MITgcm. The context and the motivations are reported in the linked PR inogs/mer#1098, which serves to prepare a data.exf compliant with the present modifications.

This is the list of the modified source files managed by diff_apply.py:
- gchem_fields_load.F
- exf_readparms.F
- exf_init_fixed.F
- exf_swapffields.F
- EXF_PARAM.h

```gchem_fields_load``` is the parent subroutine of this workflow, where it is now introduced the choice, through the parameter ```useBFMexf``` between the new version and the original one.

```exf_init_fixed``` is modified to include the initial calls to ```exf_getffield_start``` for the computation of the variables *startTime.

```exf_readparms``` is modified to initialize the new variables and read them from the new namelist in ```data.exf```.

```EXF_PARAM.h``` is modified to declare the new variables.

```exf_swapffields.F``` is modified to create a new subroutine to copy 2-d fields on the XY plane.

The core of the workflow is then managed by the new files ```BFMcoupler_exf_load.F``` and ```exf_set_BFMcoupler.F```.

```BFMcoupler_exf_load``` is called by ```gchem_fields_load``` and it calls in turn 
- ```BFMcouplerS_EXF_READ_XY``` for the surface fluxes
- ```BFMcouplerB_EXF_READ_XY``` for the bottom fluxes
- ```BFMcouplerK_EXF_READ_XY``` for the  Kext

The three subroutines are defined in the same file and each one replicates the workflow of OBCS_EXF_READ_XZ with the preparatory calls to evaluate the interpolation factor and all the separate calls to ```exf_set_BFMcoupler``` to interpolate in time for each specific file.

I added exf_set_BFMcoupler.F to the repository as a new static file and updated the TARGET_STATIC list in add_tracers.py.

I added BFMcoupler_exf_load.F.tpl in the template folder, since in that file there are some tracer-related variables (e.g. CONC01botF, etc.), and I added it to the TARGET_TPL list in add_tracers.py.

I have already run some tests by building the model (mer model build) with the --coupler-path flag and the path to my modified directory, and all the new files are written correctly.